### PR TITLE
Fixed: Image size of Profile picture

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -94,7 +94,7 @@
                 {% if PROFILE_PICTURE %}
                 <div class="row text-center">
                     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                        <img class="img-circle image100" src="{{ SITEURL }}/images/{{ PROFILE_PICTURE }}" alt="" />
+                        <img class="img-circle img-responsive" src="{{ SITEURL }}/images/{{ PROFILE_PICTURE }}" alt="" />
                     </div>
                 </div><hr />
                 {% endif %}


### PR DESCRIPTION
The original size of Profile picture is 220 x 220 PX. However, since Image is not responsive in accordance to the theme, it looks bit stretched and flat. Hence, fixed the issue by using "img-responsive img-circle" class. Please review and approve.